### PR TITLE
Document Debian prerequisites and meson setup invocation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,6 +18,12 @@ Install the following tools before building:
 - libarchive development files (e.g., `brew install libarchive`, `sudo port install libarchive`, or `sudo apt install libarchive-dev`).
 - `pkg-config` if your distribution does not include it by default.
 
+On Debian/Ubuntu systems you can install the entire toolchain with a single command:
+
+`sudo apt-get install clang lld libsqlite3-dev libarchive-dev pkg-config meson ninja-build`
+
+> **VDSO requirement:** The VDSO build step invokes Clang with LLD. If that toolchain is missing, Meson fails while building the `vdso` target with an error such as `ld.lld: error: unable to execute command: Executable "ld.lld" doesn't exist!`. Install clang and lld before retrying.
+
 To exercise the end-to-end Meson tests you will also need common userland tools on the host system, notably `wget` (used to grab the Alpine minirootfs) and `bc` (used by the test harness when summarizing results).
 
 macOS developers will also need the latest Xcode in order to compile and sign the iOS application.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Open the project in Xcode, open iSH.xcconfig, and change `ROOT_BUNDLE_IDENTIFIER
 
 ## Build command line tool for testing
 
-To set up your environment, cd to the project and run `meson build` to create a build directory in `build`. Then cd to the build directory and run `ninja`.
+To set up your environment, cd to the project and run `meson setup build` to create a build directory in `build`. Then cd to the build directory and run `ninja`.
 
 To set up a self-contained Alpine linux filesystem, download the Alpine minirootfs tarball for i386 from the [Alpine website](https://alpinelinux.org/downloads/) and run `./tools/fakefsify`, with the minirootfs tarball as the first argument and the name of the output directory as the second argument. Then you can run things inside the Alpine filesystem with `./ish -f alpine /bin/sh`, assuming the output directory is called `alpine`. If `tools/fakefsify` doesn't exist for you in your build directory, that might be because it couldn't find libarchive on your system (see above for ways to install it.)
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -38,7 +38,7 @@ iSHは、ユーザーモードのx86エミュレーションとシステムコ�
 
 ## テスト用のコマンドラインツールをビルドする
 
-環境を設定するには、プロジェクトディレクトリに移動し、`meson build`を実行して`build`ディレクトリを作成します。その後、buildディレクトリに移動し、`ninja`を実行します。
+環境を設定するには、プロジェクトディレクトリに移動し、`meson setup build`を実行して`build`ディレクトリを作成します。その後、buildディレクトリに移動し、`ninja`を実行します。
 
 自己完結型のAlpine linuxファイルシステムを設定するには、[Alpineウェブサイト](https://alpinelinux.org/downloads/)からi386用のAlpine minirootfs tarballをダウンロードし、`./tools/fakefsify`を実行します。minirootfs tarballを最初の引数として、出力ディレクトリの名前を2番目の引数として指定します。その後、`./ish -f alpine /bin/sh`を使用して、Alpineファイルシステム内でコマンドを実行できます。出力ディレクトリの名前が`alpine`であると仮定します。`tools/fakefsify`がbuildディレクトリに存在しない場合、それはシステム上でlibarchiveを見つけられなかったためかもしれません（インストール方法については上記を参照してください）。
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -41,7 +41,7 @@ Xcode로 프로젝트를 열고, iSH.xcconfig 연 후에 `ROOT_BUNDLE_IDENTIFIER
 
 ## 테스트를 위한 cli 도구 빌드하는 법
 
-환경을 세팅하기 위해서는 프로젝트 디렉토리로 이동하고 `meson build`를 커맨드 라인에 입력하세요. 그 후 빌드 된 디렉토리로 cd 후 `ninja` 커맨드를 입력해 실행하세요.
+환경을 세팅하기 위해서는 프로젝트 디렉토리로 이동하고 `meson setup build`를 커맨드 라인에 입력하세요. 그 후 빌드 된 디렉토리로 cd 후 `ninja` 커맨드를 입력해 실행하세요.
 
 자체적으로 컨테이너 화 된 Alpine 리눅스 파일 시스템으로 실행하고 싶다면, [Alpine 웹사이트](https://alpinelinux.org/downloads/) 에서 i386을 위한 Alpine minirootfs(Mini Root Filesystem) tarball 을 다운로드 받고 `./tools/fakefsify`으로 실행하세요. 매개인자로 다운로드 받은 minirootfs tarball 파일을 입력하고 출력 받을 디렉토리의 이름을 두번째 인자로 입력하면 됩니다. 그 후에는 `./ish -f {출력받을 디렉토리 이름} /bin/sh` 명령어를 사용하여 Alpine 시스템 내에서 원하는 것을 실행할 수 있습니다. 만약 `tools/fakefsify` 가 빌드 디렉토리에 존재하지 않는다면, libarchive를 찾을 수 없어서 그런 것일 수 있습니다. 위를 참고하여 시스템에 설치하는 방법을 참고해주세요.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -38,7 +38,7 @@ iSH 是一个运行在 iOS 上的 Linux shell。本项目使用了 x86 用户模
 
 ## 为测试构建命令行工具
 
-在项目目录中运行命令 `meson build`，之后 `build` 目录会被创建。进入到 `build` 目录并运行命令 `ninja`。
+在项目目录中运行命令 `meson setup build`，之后 `build` 目录会被创建。进入到 `build` 目录并运行命令 `ninja`。
 
 为了建立一个自有的 Alpine linux 文件系统，请从 [Alpine 网站](https://alpinelinux.org/downloads/) 下载 `Alpine minirotfs tarball for i386` 并运行 `tools/fakefsify` 。将 minirotfs tarball 指定为第一个参数，将输出目录的名称（如`alpine`）指定为第二个参数，即 `tools/fakefsify $MinirotfsTarballFilename alpine` 然后在 Alpine 文件系统中运行 `/ish -f alpine/bin/sh`。如果 `build` 目录下找不到 `tools/fakefsify`，可能是系统上找不到 `libarchive` 的依赖（请参照前面的章节进行安装）。
 


### PR DESCRIPTION
## Summary
- add a single apt-get invocation covering the Linux build prerequisites and note the VDSO toolchain requirement
- align README quick-start instructions (and translations) with `meson setup build`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cba6d799708320ac7dfa731dfa3ab3